### PR TITLE
Transfer Wizard

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,14 @@
 # Changelog for bag-of-holding
 
+## 1.1.0 (2019-12-03)
+
+The former `t` command for writing Pact Transactions has been moved to `p`. In
+its place, `t` now opens the Transfer Wizard. Use this to easily perform
+single-chain transfers without writing your own Pact code.
+
+**Note:** General transactions are still broken, but will be fixed in the next
+version.
+
 ## 1.0.1 (2019-11-29)
 
 The dependency on `chainweb` has been dropped, vastly reducing the number of

--- a/bag-of-holding.cabal
+++ b/bag-of-holding.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               bag-of-holding
-version:            1.0.1
+version:            1.1.0
 synopsis:           A terminal-based wallet for Chainweb.
 description:        A terminal-based wallet for Chainweb.
 homepage:           https://github.com/kadena-community/bag-of-holding

--- a/exec/BOH.hs
+++ b/exec/BOH.hs
@@ -37,7 +37,7 @@ main = execParser opts >>= env >>= \case
       ""
       (focusRing [minBound ..])
       (replForm e . REPL (ChainId 0) Local (TxData Null) . fromJust $ code "(+ 1 1)")
-      (transferForm e $ Trans (ChainId 0) "" 0 False)
+      (transferForm e $ Trans (ChainId 0) (Receiver $ Account "") 0 False)
       []
       Nothing
 

--- a/exec/BOH.hs
+++ b/exec/BOH.hs
@@ -36,7 +36,9 @@ main = execParser opts >>= env >>= \case
       (L.list TXList mempty 1)
       ""
       (focusRing [minBound ..])
-      (replForm e . REPL (ChainId 0) Local (TxData Null) . fromJust $ code "(+ 1 1)") []
+      (replForm e . REPL (ChainId 0) Local (TxData Null) . fromJust $ code "(+ 1 1)")
+      (transferForm e $ Trans (ChainId 0) "" 0)
+      []
       Nothing
 
     opts :: ParserInfo Args

--- a/exec/BOH.hs
+++ b/exec/BOH.hs
@@ -37,7 +37,7 @@ main = execParser opts >>= env >>= \case
       ""
       (focusRing [minBound ..])
       (replForm e . REPL (ChainId 0) Local (TxData Null) . fromJust $ code "(+ 1 1)")
-      (transferForm e $ Trans (ChainId 0) "" 0)
+      (transferForm e $ Trans (ChainId 0) "" 0 False)
       []
       Nothing
 

--- a/lib/Holding.hs
+++ b/lib/Holding.hs
@@ -322,7 +322,7 @@ send' :<|> poll' :<|> listen' :<|> local' = client (Proxy @PactAPI)
 newtype Sender = Sender Account
 
 -- | The receiver `Account` in a coin transfer.
-newtype Receiver = Receiver Account
+newtype Receiver = Receiver Account deriving stock (Generic)
 
 -- | The @coin.get-balance@ function.
 balance :: Account -> Maybe PactCode

--- a/lib/Holding.hs
+++ b/lib/Holding.hs
@@ -19,6 +19,7 @@ module Holding
   , transaction
   , command
   , TxData(..)
+  , gasCap, transferCap
     -- ** Pact Communication
   , Account(..)
   , meta
@@ -64,6 +65,7 @@ import qualified Pact.ApiReq as P
 import qualified Pact.Compile as P
 import qualified Pact.Parse as P
 import qualified Pact.Types.API as P
+import qualified Pact.Types.Capability as P
 import qualified Pact.Types.Command as P
 import qualified Pact.Types.Crypto as P
 import qualified Pact.Types.Hash as P
@@ -87,7 +89,6 @@ DO:
 - [ ] Allow simple transfers, cross-chain transfers, and balance checks (single-sig only).
 - [x] Manage active `RequestKeys` in a sane way.
 - [x] Allow short, custom TXs to be written.
-- [ ] Track health of the bootstrap nodes.
 - [x] Pretty-print the results of TXs.
 - [x] Show a history of recent TXs.
 - [x] LISTEN ON PORT 9467 FOR SIGNING TXS IN DAPPS! HAVE MANUAL CONFIRMATION WITHIN WALLET!
@@ -174,14 +175,32 @@ command = to cmdt
 
 -- | Form some parsed `PactCode` into a `Transaction` that's sendable to a running
 -- Chainweb instance.
-transaction :: ChainwebVersion -> TxData -> PactCode -> Keys -> P.PublicMeta -> IO Transaction
-transaction v (TxData td) (PactCode pc) (Keys ks) pm =
-  Transaction <$> P.mkExec (T.unpack pc) td pm [(ks, mempty)] nid Nothing
+transaction
+  :: ChainwebVersion
+  -> TxData
+  -> PactCode
+  -> [P.SigCapability]
+  -> Keys
+  -> P.PublicMeta
+  -> IO Transaction
+transaction v (TxData td) (PactCode pc) caps (Keys ks) pm =
+  Transaction <$> P.mkExec (T.unpack pc) td pm [(ks, caps)] nid Nothing
   where
     nid :: Maybe P.NetworkId
     nid = Just . P.NetworkId $ chainwebVersionToText v
 
 newtype TxData = TxData Value deriving newtype (ToJSON, FromJSON)
+
+gasCap :: P.SigCapability
+gasCap = P.SigCapability (P.QualifiedName "coin" "GAS" (P.mkInfo "coin.GAS")) []
+
+-- TODO Newtype the decimal value.
+transferCap :: Sender -> Receiver -> Double -> P.SigCapability
+transferCap (Sender (Account s)) (Receiver (Account r)) m =
+  P.SigCapability (P.QualifiedName "coin" "TRANSFER" (P.mkInfo "coin.TRANSFER"))
+  [ P.PLiteral $ P.LString s
+  , P.PLiteral $ P.LString r
+  , P.PLiteral $ P.LDecimal $ realToFrac m ]
 
 --------------------------------------------------------------------------------
 -- Pact Communication


### PR DESCRIPTION
`t` now opens the Transfer Wizard, allowing one to perform single-chain transfers without writing your own Pact code or concerning yourself with Capabilities.