### PR TITLE
Enforce proper rounding

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for bag-of-holding
 
+## 1.1.1 (2019-12-10)
+
+Fixed a bug involving decimal places entered into the Transfer Wizard.
+
 ## 1.1.0 (2019-12-03)
 
 The former `t` command for writing Pact Transactions has been moved to `p`. In

--- a/bag-of-holding.cabal
+++ b/bag-of-holding.cabal
@@ -43,6 +43,7 @@ library
     Holding.Chainweb
 
   build-depends:
+    , Decimal        ^>=0.5
     , prettyprinter  ^>=1.2
     , servant        ^>=0.16
     , time           ^>=1.8

--- a/bag-of-holding.cabal
+++ b/bag-of-holding.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               bag-of-holding
-version:            1.1.0
+version:            1.1.1
 synopsis:           A terminal-based wallet for Chainweb.
 description:        A terminal-based wallet for Chainweb.
 homepage:           https://github.com/kadena-community/bag-of-holding

--- a/exec/BOH/UI.hs
+++ b/exec/BOH/UI.hs
@@ -83,7 +83,7 @@ data REPL = REPL { rcid :: !ChainId, re :: !Endpoint, dat :: !TxData, rpc :: !Pa
 data Trans = Trans
   { tcid     :: !ChainId
   , receiver :: !Receiver
-  , amount   :: !Double
+  , amount   :: !KDA
   , confirm  :: Bool }
   deriving stock (Generic)
 
@@ -272,11 +272,9 @@ goodAccount (a:_)
   where
     len = T.length a
 
-goodAmount :: [Text] -> Maybe Double
+goodAmount :: [Text] -> Maybe KDA
 goodAmount []     = Nothing
-goodAmount (dt:_) = do
-  d <- readMaybe $ T.unpack dt
-  bool Nothing (Just d) $ d >= 0.000_000_000_001
+goodAmount (dt:_) = readMaybe (T.unpack dt) >>= kda
 
 --------------------------------------------------------------------------------
 -- Event Handling

--- a/exec/BOH/UI.hs
+++ b/exec/BOH/UI.hs
@@ -69,7 +69,7 @@ data Wallet = Wallet
   , focOf   :: !(FocusRing Name)
   , replOf  :: !(Form REPL SignReq Name)
   , transOf :: !(Form Trans SignReq Name)
-  , balsOf  :: [(ChainId, Maybe Double)]
+  , balsOf  :: [(ChainId, Maybe KDA)]
   , reqOf   :: Maybe SignReq }
   deriving stock (Generic)
 
@@ -160,7 +160,7 @@ draw e w = dispatch <> [ui]
         total :: Widget w
         total = txt "Total   => " <+> str (show . sum . mapMaybe snd $ balsOf w)
 
-        f :: (ChainId, Maybe Double) -> Widget Name
+        f :: (ChainId, Maybe KDA) -> Widget Name
         f (cid, md) = hBox
           [ txt "Chain ", txt (chainIdToText cid), txt " => "
           , str $ maybe "Balance check failed." show md ]
@@ -393,7 +393,7 @@ mainEvent e w (VtyEvent ve) = case ve of
       cs = L.sort . toList . chainIds $ verOf e
       cd = balance $ accOf e
       rs = map (\cid -> (cid, REPL cid Local (TxData Null) <$> cd)) cs
-      ds = preview (_Just . position @2 . _Right . _Ctor @"T" . pactDouble)
+      ds = preview (_Just . position @2 . _Right . _Ctor @"T" . pactDouble . to kda . _Just)
 
   -- Help Window --
   V.EvKey (V.KChar 'h') [] -> continue (w & field @"focOf" %~ focusSetCurrent Help)

--- a/lib/Holding.hs
+++ b/lib/Holding.hs
@@ -248,8 +248,8 @@ newtype TXResult = TXResult { txr :: P.CommandResult P.Hash }
 pactValue :: Traversal' TXResult P.PactValue
 pactValue = _Unwrapped . P.crResult . _Unwrapped . _Right
 
-pactDouble :: SimpleFold TXResult Double
-pactDouble = pactValue . _Ctor @"PLiteral" . _Ctor @"LDecimal" . to realToFrac
+pactDouble :: SimpleFold TXResult Decimal
+pactDouble = pactValue . _Ctor @"PLiteral" . _Ctor @"LDecimal"
 
 --------------------------------------------------------------------------------
 -- Endpoint Calls


### PR DESCRIPTION
This PR introduced the `KDA` wrapper for `Decimal`, used to enforce the 12 digit limit after the decimal point.